### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/apolitis-work/survey/v2
+module github.com/yext/survey/v2
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8


### PR DESCRIPTION
This change updates the module name to match its current location in
order to allow it to be fetchable via `go get`.